### PR TITLE
Fix SQL query to include wildcards for name search

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,7 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE %s", name
+            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
This pull request updates the SQL query used to filter books by name in the `index` route. The change modifies how the query is constructed to include partial matches for the provided name.

Database query logic:

* In `server/routes.py`, the SQL query in the `index` route now uses string concatenation to search for books where the name contains the provided substring, enabling partial matches.